### PR TITLE
feat: implement Projects page, just structure no styles

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = [
   {   
     rules: {
       indent: ["error", 2], // Enforce 2-space indentation
+      "max-len": ["error", { code: 100 }], // Enforce a maximum line length of 100 characters
+      
     },
   }
 ];

--- a/src/app/components/ProjectCard/ProjectCard.tsx
+++ b/src/app/components/ProjectCard/ProjectCard.tsx
@@ -1,0 +1,27 @@
+import { Project } from "@/app/models/projects";
+
+const ProjectCard = ({
+  description,
+  id,
+  name,
+  technologies,
+  url,
+}: Project) => {
+  return (
+    <div key={id}>
+      <h1>{name}</h1>
+      <p>{description}</p>
+      <a href={url}>View Project</a>
+      <div>
+        {technologies.map((technology) => (
+          <span key={technology.name}>
+            {technology.name}
+          </span>
+        ))}
+      </div>
+    </div>
+       
+  );
+};
+
+export default ProjectCard;

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,22 @@
+import ProjectCard from "../components/ProjectCard/ProjectCard";
+import { PROJECTS_LIST } from "../constants";
+
 const ProjectsPage = () => {
-    return (
-        <div className="flex flex-col items-center justify-center h-screen">
-        <h1 className="text-4xl font-bold">Projects</h1>
-        <p className="mt-4 text-lg">Coming soon...</p>
-        </div>
-    );
+  return (
+    <div className="flex flex-col items-center justify-center h-screen">
+      {
+        PROJECTS_LIST.map((project) => (
+          <ProjectCard 
+            description={project.description} 
+            id={project.id} name={project.name} 
+            technologies={project.technologies} 
+            url={project.url} key={project.id} 
+            github={project.github} icon={project.icon} 
+          />
+        ))
+      }
+    </div>
+  );
 };
+
 export default ProjectsPage;


### PR DESCRIPTION
This pull request introduces a new `ProjectCard` component to display project details, integrates it into the `ProjectsPage`, and updates the ESLint configuration to enforce a maximum line length. Below are the key changes grouped by theme:

### Component Addition and Integration:

* **New `ProjectCard` Component**: Created a reusable `ProjectCard` component in `src/app/components/ProjectCard/ProjectCard.tsx` to display project details, including name, description, URL, and associated technologies.
* **Integration into `ProjectsPage`**: Updated `src/app/projects/page.tsx` to use the `ProjectCard` component for rendering a list of projects dynamically from the `PROJECTS_LIST` constant. This replaces placeholder text with actual project data.

### Code Quality:

* **ESLint Configuration Update**: Added a rule in `eslint.config.mjs` to enforce a maximum line length of 100 characters for better code readability.